### PR TITLE
chroe: fix quest resources links

### DIFF
--- a/docs/quest-resources/index.md
+++ b/docs/quest-resources/index.md
@@ -8,8 +8,12 @@ has_toc: false
 
 A quest might be dependent on resources being functional before a user can start the quest. In many cases, a quest might require configuration to be removed. An example for that is when a user plays the same quest again and needs to clear any configurations added during the previous playthrough.
 
-| Name | Description |
-|----------------|----------|
-| [heroku_backend](Quest%20Resources/heroku_backend.md) | Heroku app hosting the backend |
-| [heroku_frontend](Quest%20Resources/heroku_frontend.md) | Heroku app hosting the frontend |
-| [user](Quest%20Resources/user.md) | Used to modify user configuration |
+| Name              | Description                       |
+|-------------------|-----------------------------------|
+| [heroku_backend]  | Heroku app hosting the backend    |
+| [heroku_frontend] | Heroku app hosting the frontend   |
+| [user]            | Used to modify user configuration |
+
+[heroku_backend]: {% link docs/quest-resources/heroku-backend.md %}
+[heroku_frontend]: {% link docs/quest-resources/heroku-frontend.md %}
+[user]: {% link docs/quest-resources/user.md %}


### PR DESCRIPTION
Fix broken links in the quest resources index file, and format the table