### PR TITLE
fix: remove unicode chars from example

### DIFF
--- a/docs/building-your-quest/actions/bot-message.md
+++ b/docs/building-your-quest/actions/bot-message.md
@@ -46,7 +46,7 @@ startFlow:
           job.
         delay: 2500
       - text: "So, to help familiarize you with your new work environment, I was thinking
-          that maybe you first should set it up. \U0001F60A"
+          that maybe you first should set it up."
         delay: 3000
       - text: Just **let me know once you’re ready** to start your first task!
         delay: 5000


### PR DESCRIPTION
Remove unicode characters from an example