### PR TITLE
Solved typo in Creating Steps page causing 404

### DIFF
--- a/docs/building-your-quest/creating-steps.md
+++ b/docs/building-your-quest/creating-steps.md
@@ -28,7 +28,7 @@ trigger: Trigger type and flow node logic. Each step has one trigger | mandatory
 githubAction: Github Actions configuration to run in opened PRs | optional
 ```
 
-→ [Triggers and Payload](triggers-and-payload.html)
+→ [Triggers and Payload](triggers-and-payloads.html)
 
 → [Flow Nodes](flow-nodes.html)
 


### PR DESCRIPTION
**Describe the bug**
triggers-and-payload page causing 404 on the Creating Steps page

**To Reproduce**
Steps to reproduce the behavior:
1. Go to https://dev.trywilco.com/docs/building-your-quest/creating-steps.html
2. Click Triggers and Payload link
3. It causes a 404 because a simple typo in the link
triggers-and-payload.html should be ---> triggers-and-**payloads**.html
