### PR TITLE
Fix a broken link

### DIFF
--- a/docs/building-your-quest/creating-steps.md
+++ b/docs/building-your-quest/creating-steps.md
@@ -28,7 +28,7 @@ trigger: Trigger type and flow node logic. Each step has one trigger | mandatory
 githubAction: Github Actions configuration to run in opened PRs | optional
 ```
 
-→ [Triggers and Payload](triggers-and-payload.html)
+→ [Triggers and Payloads](triggers-and-payloads.html)
 
 → [Flow Nodes](flow-nodes.html)
 


### PR DESCRIPTION
The link pointed to a non-existing page "Triggers and Payload". The PR fixes the link (and name for the link).

https://dev.trywilco.com/docs/building-your-quest/creating-steps.html

<img width="376" alt="Screenshot 2022-12-09 at 23 15 28" src="https://user-images.githubusercontent.com/668391/206804441-7386805f-62d6-4262-88cf-963c75fa0ebf.png">
