### PR TITLE
feat: focus search on cmd k

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,8 @@
+<script>
+    function onKeyDown(event) {
+        if (event.metaKey && event.keyCode === 75) {
+            document.getElementById('search-input')?.focus();
+        }
+    }
+    window.addEventListener('keydown', onKeyDown);
+</script>


### PR DESCRIPTION
Focus on search when hitting cmd+k. 

This currently only focus on the input, but doesn't open the menu until the first letter is typed.

https://www.loom.com/share/90916a6808244e21a4b6642ddde7c94b