### PR TITLE
Add docker-compose to simplify development setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
-FROM ruby:3.1
+FROM ruby:3.1 AS base
 WORKDIR /app
-COPY . /app
+COPY Gemfile Gemfile.lock ./
 RUN bundle install
+
+FROM base AS dev
+CMD ["jekyll", "serve", "--host", "0.0.0.0", "--livereload", "--livereload-port", "35729"]
+
+FROM base AS build
+COPY . /app
 RUN bundle exec jekyll build

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-19

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Assuming [Ruby], [Jekyll] and [Bundler] are installed on your computer:
 
     The built site is stored in the directory `_site`.
 
+### Using Docker
+
+If you have Docker installed on your machine:
+
+1. Clone this repository.
+
+2. Run `docker compose up`. Preview the site at `localhost:4000`. Livereload will automatically refresh your browser as changes are made.
+
 ## Deployment
 
 Any commits to main trigger an automatic rebuild and deployment to [dev.trywilco.com]. You can see the [deployment status here](https://github.com/trywilco/wilco-docs/deployments).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  docs:
+    build:
+      context: ./
+      target: dev
+    ports:
+      - 4000:4000
+      - 35729:35729
+    volumes:
+      - ./:/app


### PR DESCRIPTION
I was going to contribute a few docs updates while working on building a quest, but I don't have all of the Ruby stack installed on my machine. So, took a few minutes to setup a Compose file to simplify the dev environment setup. A few notes:

- I had to pin the `Dockerfile` to `ruby:3.1.2` because of [this bug](https://github.com/jekyll/jekyll/issues/9233) I ran into that prevented Jekyll builds from succeeding in the latest versions of Ruby
- The compose file will use the same Dockerfile for the dev environment, but a stage specifically focused on development
- Livereload is enabled and explicitly specifies its port (although that's the default port)

Happy for feedback! If you decide not to merge, no worries! Didn't take too long to put together to help myself contribute. But, happy to share if it's something you want to merge and/or might be beneficial to others. Thanks!