### PR TITLE
add instructions for mac

### DIFF
--- a/docs/upload-and-test/upload-using-cli-tool.md
+++ b/docs/upload-and-test/upload-using-cli-tool.md
@@ -11,8 +11,9 @@ A command line tool can be used to automate the process of zipping and uploading
 Download the executable according to the operating system you use:
 
 * [Windows]
-* [Mac]
 * [Linux]
+* [Mac]
+   - You might need to tell Mac that the executable is from a trustworthy source. Click [here](https://support.apple.com/en-my/guide/mac-help/mchleab3a043/mac) for instructions
 
 The following arguments are supported:
 


### PR DESCRIPTION
Add link to instructions in case Mac refuses to open the executable because it is from unknown source