### PR TITLE
Moved the conditions.md file

### DIFF
--- a/docs/building-your-quest/conditions/index.md
+++ b/docs/building-your-quest/conditions/index.md
@@ -1,5 +1,6 @@
 ---
 title: Conditions
+has_children: true
 parent: Building Your Quest
 has_children: true
 nav_order: 5

--- a/docs/building-your-quest/creating-steps.md
+++ b/docs/building-your-quest/creating-steps.md
@@ -38,4 +38,4 @@ githubAction: Github Actions configuration to run in opened PRs | optional
 [Triggers and Payload]: {% link docs/building-your-quest/triggers-and-payloads.md %}
 [Flow Nodes]: {% link docs/building-your-quest/flow-nodes.md %}
 [Actions]: {% link docs/building-your-quest/actions/index.md %}
-[Conditions]: {% link docs/building-your-quest/conditions.md %}
+[Conditions]: {% link docs/building-your-quest/conditions/index.md %}


### PR DESCRIPTION
The conditions.md file was supposed to be in the conditions folder as index.md if it was to match the style of the rest of the quest building SDK. This move and name change broke a link in the creating-steps.md file that has since been fixed.