### PR TITLE
remove person param fro all git messages

### DIFF
--- a/docs/building-your-quest/actions/github-pr-approve.md
+++ b/docs/building-your-quest/actions/github-pr-approve.md
@@ -18,7 +18,6 @@ Approve the PR and add comment on behalf of a bot
 
 ## Params
 
-- **person:** Name of the bot. e.g., `keen` or `lucca`
 - **message:** The comment text
     
     [Text Formatting]
@@ -34,7 +33,6 @@ No additional info is added to the global payload outputs.
 do:
 - actionId: github_pr_approve
   params:
-    person: keen
     message: "Nailed it! Excellent job @${user.githubuser}! You can now merge the PR."
 ```
 

--- a/docs/building-your-quest/actions/github-pr-comment.md
+++ b/docs/building-your-quest/actions/github-pr-comment.md
@@ -18,7 +18,6 @@ Add comment on a PR on behalf of one the bots
 
 ## Params
 
-- **person:** Name of the bot. e.g., `keen` or `lucca`
 - **message:** The comment text
     
     [Text Formatting]
@@ -34,7 +33,6 @@ No additional info is added to the global payload outputs.
 do:          
 - actionId: github_pr_comment
   params:
-    person: keen
     message: "On it, I'll review the changes right away."
 ```
 

--- a/docs/building-your-quest/actions/github-pr-reject.md
+++ b/docs/building-your-quest/actions/github-pr-reject.md
@@ -18,7 +18,6 @@ Reject the PR (request changes) and add comment on behalf of a bot.
 
 ## Params
 
-- **person:** Name of the bot. e.g., `keen` or `lucca`
 - **message:** The comment text
     
     [Text Formatting]
@@ -34,7 +33,6 @@ No additional info is added to the global payload outputs.
 do:
 - actionId: github_pr_reject
   params:
-    person: keen
     message: "Looks like this code change didn’t fix the problem. Can you take a second look?"
 ```
 

--- a/docs/building-your-quest/conditions/index.md
+++ b/docs/building-your-quest/conditions/index.md
@@ -116,7 +116,6 @@ if:
           delay: 1000
     - actionId: github_pr_approve
       params:
-        person: lucca
         message: "Looking good! You can merge the PR now."
 
   else:
@@ -129,7 +128,6 @@ if:
           delay: 1000
     - actionId: github_pr_reject
       params:
-        person: lucca
         message: "${pr_reject_message}"
         messageName: "${pr_reject_message_name}"
 ```

--- a/docs/building-your-quest/triggers-and-payloads.md
+++ b/docs/building-your-quest/triggers-and-payloads.md
@@ -195,7 +195,6 @@ In addition to specific payload passed by each trigger, a global payload is alwa
     ```yaml
     actionId: github_pr_approve
     params:
-      person: keen
       message: Nailed it! Excellent job @**${user.githubuser}**! You can now merge the PR.
     ```
     


### PR DESCRIPTION
Wilco now uses Github App to interact with GitHub so no need to specify bot name anymore