### PR TITLE
Using only jest-puppeteer

### DIFF
--- a/docs/building-your-quest/github-actions.md
+++ b/docs/building-your-quest/github-actions.md
@@ -97,7 +97,6 @@ githubActions:
   frontend:
     capabilities:
     - jest-puppeteer
-    - puppeteer
     testFile: "search-empty.test.js"
 ```
 


### PR DESCRIPTION
We don't need to add both now, since the jest-puppeteer capability includes jest-puppeteer and puppeteer packages.
The following lines in the docs still make sense to me, LMK if you think we should change them